### PR TITLE
Fix import issue with Python3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,13 +66,13 @@ jobs:
     - name: Store source package
       uses: actions/upload-artifact@v3
       with:
-        name: src_package
+        name: odm_src_package
         path: ./dist/${{ steps.build_package.outputs.source }}
         retention-days: 5
 
     - name: Store Wheel package
       uses: actions/upload-artifact@v3
       with:
-        name: bin_package
+        name: odm_bin_package
         path: ./dist/${{ steps.build_package.outputs.wheel }}
         retention-days: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,13 +116,13 @@ jobs:
     - name: Download Source package
       uses: actions/download-artifact@v3
       with:
-        name: src_package
+        name: odm_src_package
         path: ${{ github.workspace }}/
 
     - name: Download Linux package
       uses: actions/download-artifact@v3
       with:
-        name: bin_package
+        name: odm_bin_package
         path: ${{ github.workspace }}/
 
     # --- Create Release --- #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: bin_package
+        name: odm_bin_package
         path: ${{ github.workspace }}/
 
     - name: install package

--- a/oasis_data_manager/df_reader/config.py
+++ b/oasis_data_manager/df_reader/config.py
@@ -1,9 +1,14 @@
 import json
+import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, TypedDict, Union
 
-from typing_extensions import NotRequired
+if sys.version_info >= (3, 8):
+    from typing import Any, Dict, TypedDict, Union
+    from typing_extensions import NotRequired
+else:
+    from typing import Any, Dict, Union
+    from typing_extensions import NotRequired, TypedDict
 
 from ..config import ConfigError, load_class
 from ..filestore.backends.local import LocalStorage

--- a/oasis_data_manager/filestore/config.py
+++ b/oasis_data_manager/filestore/config.py
@@ -1,8 +1,13 @@
 import json
 import os
-from typing import Optional, Tuple, TypedDict, Union
+import sys
 
-from typing_extensions import NotRequired
+if sys.version_info >= (3, 8):
+    from typing import Optional, Tuple, TypedDict, Union
+    from typing_extensions import NotRequired
+else:
+    from typing import Optional, Tuple, Union
+    from typing_extensions import NotRequired, TypedDict
 
 from oasis_data_manager.config import ConfigError, load_class
 from oasis_data_manager.filestore.backends.base import BaseStorage

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,4 +1,5 @@
 fastparquet
 fsspec
 pandas
+typing
 typing_extensions


### PR DESCRIPTION
### Fix import issue with Python3.7 
Added workaround to fix `ImportError: cannot import name 'TypedDict' from 'typing'`  which isn't available in **py3.7** 
<!--end_release_notes-->
