### PR TITLE
Pin fsspec 

### DIFF
--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,5 +1,5 @@
 fastparquet
-fsspec
+fsspec>=2023.12.2
 pandas
 typing
 typing_extensions


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed package requirments to pin fsspec
 `fsspec >=2023.12.2` is needed otherwise running oasislmf can fail with
 ```
   File "/home/joh/venv38/lib/python3.8/site-packages/oasis_data_manager/df_reader/config.py", line 14, in <module>
    from ..filestore.backends.local import LocalStorage
  File "/home/joh/venv38/lib/python3.8/site-packages/oasis_data_manager/filestore/backends/local.py", line 4, in <module>
    from oasis_data_manager.filestore.backends.base import BaseStorage, MissingInputsException
  File "/home/joh/venv38/lib/python3.8/site-packages/oasis_data_manager/filestore/backends/base.py", line 16, in <module>
    from fsspec.implementations.dirfs import DirFileSystem
ModuleNotFoundError: No module named 'fsspec.implementations.dirfs'
 ```
<!--end_release_notes-->
