### PR TITLE
improve is_parquet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11.8"]
+        python-version: ["3.9", "3.10", "3.11.8"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,5 @@ jobs:
 
     - name: Run tests
       run: |
-        docker-compose up -d
+        docker compose up -d
         pytest

--- a/oasis_data_manager/df_reader/backends/base.py
+++ b/oasis_data_manager/df_reader/backends/base.py
@@ -64,11 +64,22 @@ class OasisReader:
     def _read(self):
         if not self.has_read:
             if hasattr(self.filename_or_buffer, "name"):
-                extension = pathlib.Path(self.filename_or_buffer.name).suffix
+                parts = pathlib.Path(self.filename_or_buffer.name).parts
             else:
-                extension = pathlib.Path(self.filename_or_buffer).suffix
+                parts = pathlib.Path(self.filename_or_buffer).parts
 
-            if extension in [".parquet", ".pq"]:
+            for part in parts:
+                for extension in [".parquet", ".pq"]:
+                    if part.endswith(extension):
+                        is_parquet = True
+                        break
+                else:
+                    continue  # if parquet extension is found the outer break will be called exiting the for with is_parquet = True
+                break
+            else:
+                is_parquet = False
+
+            if is_parquet:
                 self.has_read = True
                 self.read_parquet(*self.reader_args, **self.reader_kwargs)
             else:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Make all folder with parquet extension, pass the is parquet check
To improve on the read time of parquet dataset, specifying the partition folder can be useful. In that case the extention of the folder is not a parquet extension, only the parent is.
ex:
/static/footprint.parquet/event_id=1
This change will detect parquet partition if any of the parent directory is a parquet extension

This change helps with issue https://github.com/OasisLMF/OasisLMF/issues/1600



<!--end_release_notes-->
