### PR TITLE
fix connection string setup

### DIFF
--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -117,10 +117,10 @@ class AzureABFSStorage(BaseStorage):
         else:
             cs = ""
             if self.endpoint_url:
-                cs += f"BlobEndpoint={self.fs.fs.endpoint_url};"
-            if self.account_name:
+                cs += f"BlobEndpoint={self.endpoint_url};"
+            if self.fs.fs.account_name:
                 cs += f"AccountName={self.fs.fs.account_name};"
-            if self.account_key:
+            if self.fs.fs.account_key:
                 cs += f"AccountKey={self.fs.fs.account_key};"
 
             return cs

--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -104,7 +104,7 @@ class AzureABFSStorage(BaseStorage):
     def get_fsspec_storage_options(self):
         return {
             "anon": not self.account_key,
-            "connection_string": self.connection_string,
+            "connection_string": self._connection_string,
             "account_name": self.account_name,
             "account_key": self.account_key,
             "use_ssl": self.azure_ssl,
@@ -117,11 +117,11 @@ class AzureABFSStorage(BaseStorage):
         else:
             cs = ""
             if self.endpoint_url:
-                cs += f"BlobEndpoint={self.endpoint_url};"
+                cs += f"BlobEndpoint={self.fs.endpoint_url};"
             if self.account_name:
-                cs += f"AccountName={self.account_name};"
+                cs += f"AccountName={self.fs.account_name};"
             if self.account_key:
-                cs += f"AccountKey={self.account_key};"
+                cs += f"AccountKey={self.fs.account_key};"
 
             return cs
 
@@ -132,17 +132,7 @@ class AzureABFSStorage(BaseStorage):
 
         params = {}
         if encode_params:
-            if self.connection_string:
-                params["connection_string"] = self.connection_string
-            else:
-                if self.account_name:
-                    params["account"] = self.account_name
-
-                if self.account_key:
-                    params["key"] = self.account_key
-
-                if self.endpoint_url:
-                    params["endpoint"] = self.endpoint_url
+            params["connection_string"] = self.connection_string
 
         return (
             filename,

--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -118,10 +118,10 @@ class AzureABFSStorage(BaseStorage):
             cs = ""
             if self.endpoint_url:
                 cs += f"BlobEndpoint={self.endpoint_url};"
-            if self.fs.fs.account_name:
-                cs += f"AccountName={self.fs.fs.account_name};"
-            if self.fs.fs.account_key:
-                cs += f"AccountKey={self.fs.fs.account_key};"
+            if self.account_name:
+                cs += f"AccountName={self.account_name};"
+            if self.account_key:
+                cs += f"AccountKey={self.account_key};"
 
             return cs
 
@@ -132,7 +132,17 @@ class AzureABFSStorage(BaseStorage):
 
         params = {}
         if encode_params:
-            params["connection_string"] = self.connection_string
+            if self.connection_string:
+                params["connection_string"] = self.connection_string
+            else:
+                if self.account_name:
+                    params["account"] = self.account_name
+
+                if self.account_key:
+                    params["key"] = self.account_key
+
+                if self.endpoint_url:
+                    params["endpoint"] = self.endpoint_url
 
         return (
             filename,

--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -104,7 +104,7 @@ class AzureABFSStorage(BaseStorage):
     def get_fsspec_storage_options(self):
         return {
             "anon": not self.account_key,
-            "connection_string": self._connection_string,
+            "connection_string": self.connection_string,
             "account_name": self.account_name,
             "account_key": self.account_key,
             "use_ssl": self.azure_ssl,
@@ -115,13 +115,21 @@ class AzureABFSStorage(BaseStorage):
         if self._connection_string:
             return self._connection_string
         else:
+            fsspec_storage_options = {
+                "anon": not self.account_key,
+                "account_name": self.account_name,
+                "account_key": self.account_key,
+                "use_ssl": self.azure_ssl,
+            }
+            fs = self.fsspec_filesystem_class(**fsspec_storage_options)
+
             cs = ""
             if self.endpoint_url:
                 cs += f"BlobEndpoint={self.endpoint_url};"
-            if self.fs.fs.account_name:
-                cs += f"AccountName={self.fs.fs.account_name};"
-            if self.fs.fs.account_key:
-                cs += f"AccountKey={self.fs.fs.account_key};"
+            if fs.account_name:
+                cs += f"AccountName={fs.account_name};"
+            if fs.account_key:
+                cs += f"AccountKey={fs.account_key};"
 
             return cs
 

--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -117,11 +117,11 @@ class AzureABFSStorage(BaseStorage):
         else:
             cs = ""
             if self.endpoint_url:
-                cs += f"BlobEndpoint={self.fs.endpoint_url};"
+                cs += f"BlobEndpoint={self.fs.fs.endpoint_url};"
             if self.account_name:
-                cs += f"AccountName={self.fs.account_name};"
+                cs += f"AccountName={self.fs.fs.account_name};"
             if self.account_key:
-                cs += f"AccountKey={self.fs.account_key};"
+                cs += f"AccountKey={self.fs.fs.account_key};"
 
             return cs
 

--- a/oasis_data_manager/filestore/backends/azure_abfs.py
+++ b/oasis_data_manager/filestore/backends/azure_abfs.py
@@ -118,10 +118,10 @@ class AzureABFSStorage(BaseStorage):
             cs = ""
             if self.endpoint_url:
                 cs += f"BlobEndpoint={self.endpoint_url};"
-            if self.account_name:
-                cs += f"AccountName={self.account_name};"
-            if self.account_key:
-                cs += f"AccountKey={self.account_key};"
+            if self.fs.fs.account_name:
+                cs += f"AccountName={self.fs.fs.account_name};"
+            if self.fs.fs.account_key:
+                cs += f"AccountKey={self.fs.fs.account_key};"
 
             return cs
 
@@ -132,17 +132,7 @@ class AzureABFSStorage(BaseStorage):
 
         params = {}
         if encode_params:
-            if self.connection_string:
-                params["connection_string"] = self.connection_string
-            else:
-                if self.account_name:
-                    params["account"] = self.account_name
-
-                if self.account_key:
-                    params["key"] = self.account_key
-
-                if self.endpoint_url:
-                    params["endpoint"] = self.endpoint_url
+            params["connection_string"] = self.connection_string
 
         return (
             filename,


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix connection string setup when using AZURE_STORAGE_ACCOUNT_KEY
In azure storage, the connection string parameter passed to adlfs.spec.AzureBlobFileSystem was pre-generated with only the init parameters, this bypass all over method available to retrieve connection information, for example the azure env variables.
To avoid that, we now pass the connection_string without modification.

<!--end_release_notes-->
