### PR TITLE
localstack tests fail due to no paid account

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack
+    image: localstack/localstack:3
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range


### PR DESCRIPTION
localstack/localstack now requires a paid account: https://www.reddit.com/r/devops/comments/1q5o4sv/localstack_require_account_from_march_2026/
moving to localstack/localstack:3 to go back to a free version to let tests pass