### PR TITLE
Fix running a Model with footprint file via AwsS3Storage

### DIFF
--- a/oasis_data_manager/filestore/backends/aws.py
+++ b/oasis_data_manager/filestore/backends/aws.py
@@ -19,6 +19,7 @@ class AwsS3Storage(BaseStorage):
         access_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         endpoint_url: Optional[str] = None,
+        public_bucket: bool = False,
         file_overwrite=True,
         object_parameters: Optional[dict] = None,
         auto_create_bucket=False,
@@ -92,6 +93,7 @@ class AwsS3Storage(BaseStorage):
         self.access_key = access_key
         self.secret_key = secret_key
         self.endpoint_url = endpoint_url
+        self.public_bucket = public_bucket
         self.file_overwrite = file_overwrite
         self.object_parameters = object_parameters
         self.auto_create_bucket = auto_create_bucket
@@ -128,6 +130,7 @@ class AwsS3Storage(BaseStorage):
             "access_key": self.access_key,
             "secret_key": self.secret_key,
             "endpoint_url": self.endpoint_url,
+            "public_bucket": self.public_bucket,
             "file_overwrite": self.file_overwrite,
             "object_parameters": self.object_parameters,
             "auto_create_bucket": self.auto_create_bucket,
@@ -163,7 +166,7 @@ class AwsS3Storage(BaseStorage):
         if self.reduced_redundancy:
             s3_additional_kwargs["StorageClass"] = "REDUCED_REDUNDANCY"
 
-        return {
+        options = {
             "key": self.access_key,
             "secret": self.secret_key,
             "token": self.security_token,
@@ -174,6 +177,9 @@ class AwsS3Storage(BaseStorage):
                 "region_name": self.region_name,
             },
         }
+        if self.public_bucket:
+            options["anon"] = True
+        return options
 
     def _strip_signing_parameters(self, url):
         """Duplicated Unsiged URLs from Django-Stroage

--- a/oasis_data_manager/filestore/backends/base.py
+++ b/oasis_data_manager/filestore/backends/base.py
@@ -458,9 +458,10 @@ class BaseStorage(object):
     def open(self, path, *args, **kwargs):
         if self._is_valid_url(path):
             with tempfile.TemporaryDirectory() as d:
-                with open(
-                    self.get_from_cache(path, no_cache_target=os.path.join(d, "f"))
-                ) as f:
+                local_path = self.get_from_cache(path, no_cache_target=os.path.join(d, "f"))
+                if local_path is None:
+                    raise FileNotFoundError(f"No such file or directory: '{path}'")
+                with open(local_path) as f:
                     yield f
         else:
             with self.fs.open(path, *args, **kwargs) as f:
@@ -470,7 +471,8 @@ class BaseStorage(object):
     def with_fileno(self, path, mode="rb"):
         with tempfile.TemporaryDirectory() as d:
             target = os.path.join(d, "fileno")
-            path = self.get_from_cache(path, no_cache_target=target)
-
-            with open(path, mode) as f:
+            local_path = self.get_from_cache(path, no_cache_target=target)
+            if local_path is None:
+                raise FileNotFoundError(f"No such file or directory: '{path}'")
+            with open(local_path, mode) as f:
                 yield f

--- a/oasis_data_manager/filestore/backends/base.py
+++ b/oasis_data_manager/filestore/backends/base.py
@@ -69,7 +69,7 @@ class BaseStorage(object):
     fsspec_filesystem_class: Optional[Type[fsspec.AbstractFileSystem]]
 
     def __init__(
-        self, root_dir="", cache_dir: Union[str, None] = "/tmp/data-cache", logger=None
+        self, root_dir="", cache_dir: Union[str, None] = "/tmp/data-cache", logger=None, **kwargs
     ):
         # Use for caching files across multiple runs, set value 'None' or 'False' to disable
         self.cache_root = cache_dir

--- a/oasis_data_manager/filestore/config.py
+++ b/oasis_data_manager/filestore/config.py
@@ -19,6 +19,7 @@ class S3StorageConfig(BaseStorageConfig):
     access_key: NotRequired[str]
     secret_key: NotRequired[str]
     endpoint_url: NotRequired[str]
+    public_bucket: NotRequired[bool]
     file_overwrite: NotRequired[bool]
     object_parameters: NotRequired[dict]
     auto_create_bucket: NotRequired[bool]


### PR DESCRIPTION
<!--start_release_notes-->
### Fix running a Model with footprint file via AwsS3Storage
* Oasis'mf [footprint bin read function](https://github.com/OasisLMF/OasisLMF/blob/cf720d226a45c72b1aa4de6a89661cd6cc98bab1/oasislmf/pytools/getmodel/footprint.py#L310-L321) checks for files and handles `FileNotFoundError` to detect 


```
        try:
            lookup_file = self.storage.with_fileno(footprint_bin_lookup)
            with lookup_file as f:
                lookup = mmap.mmap(f.fileno(), length=0, access=mmap.ACCESS_READ)
            df = pickle.loads(lookup)


            self.events_dict = {
                row.event_id: (row.min_areaperil_id, row.max_areaperil_id)
                for row in df.itertuples(index=False)
            }
        except FileNotFoundError:
            self.events_dict = None
```
Before this fix that would cause `TypeError`, fixed so `FileNotFoundError` is raised when not found in bucket


* Added `public_bucket` (bool)  option that sets `anon = True`  in the S3 client settings, (anonymous user)  this need an explicit setting because it prevents boto3 'walking the chain'  of credentials. (for example EC2 instance with an S3 access role attached)  



<!--end_release_notes-->
